### PR TITLE
Add Bundler support to make handling dependencies easier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,43 @@
+PATH
+  remote: .
+  specs:
+    github-labeler (0.2.0)
+      commander (~> 4.3)
+      octokit (~> 4.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.8)
+    commander (4.3.5)
+      highline (~> 1.7.2)
+    diff-lcs (1.2.5)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    highline (1.7.3)
+    multipart-post (2.0.0)
+    octokit (4.0.1)
+      sawyer (~> 0.6.0, >= 0.5.3)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    sawyer (0.6.0)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  github-labeler!
+  rspec (~> 3.3)


### PR DESCRIPTION
[Bundler](https://bundler.io) makes dependency management easier. Now anyone can clone the repo, execute `bundle` and know they have exactly the same set of gems and gem versions as everyone else contributing.
